### PR TITLE
Fix for missing README.rst in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-README.rst
+include README.rst

--- a/isit.py
+++ b/isit.py
@@ -18,7 +18,7 @@ else:
   def _u(x):
     return x
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 ##########
 # Python #


### PR DESCRIPTION
I got the following error during installation of 0.3.4 from pypi: 

```
Collecting isit==0.3.4 (from -r ../requirements.txt (line 10))
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-qlIbj9/isit/setup.py", line 40, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
```

This PR fixes the MANIFEST.in so that the README.rst gets included correctly.

I also bumped the version to 0.3.5 in advance :smile:
